### PR TITLE
Game will now check if player is at highest level when using skip key

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -298,7 +298,8 @@ function keyReleased() {
                 linesString = '';
                 mousePos1 = null;
                 mousePos2 = null;
-            } else {
+            }
+            else if (player.currentLevelNo < levels.length - 1) {
                 player.currentLevelNo += 1;
                 print(player.currentLevelNo);
             }


### PR DESCRIPTION
Fixes a bug where if a player pressed the 'n' key while on the top level (where babe is), a black screen would appear rendering the game unplayable unless the user restarted the browser.